### PR TITLE
Added check for C, python and IDL keywords

### DIFF
--- a/docs/VSS2DDSIDL.md
+++ b/docs/VSS2DDSIDL.md
@@ -50,7 +50,7 @@ Below elements are considered only if the switch ***--all-idl-features*** is sup
 
 | VSS    | DDS-IDL         |
 |--------|----------------|
-| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>enum DirectionValues{FORWARD,BACKWARD};<br>struct Direction<br>{<br>string uuid;<br>DirectionValues value;<br>};</pre>   
+| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>module Direction_M {<br>enum DirectionValues{FORWARD,BACKWARD};<br>};<br>struct Direction<br>{<br>string uuid;<br>DirectionValues value;<br>};</pre>   
 
 ## Checking generated DDS-IDL file and generating code stubs from it
 


### PR DESCRIPTION
Added C,Python and IDL keyword crosss checking and appended underscore in front of keywords
Ex: `MAP` becomes `_MAP`
Also enums now exist in their own namespace under a module wrapper, the modules name is the enum name+_M
Ex:
```module LowVoltageSystemState_M`
{
enum LowVoltageSystemStateValues{UNDEFINED,LOCK,OFF,ACC,ON,START};
};
struct LowVoltageSystemState
{
LowVoltageSystemState_M::LowVoltageSystemStateValues value;
//const string type ="sensor";
//const string description="State of the supply voltage of the control units (usually 12V).";
};```